### PR TITLE
Update PHP versions in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.3", "7.4", "8.0", "8.1", "8.2"]'
-      current_stable: 8.3
+      old_stable: '["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
+      current_stable: 8.5

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2024 Akihito Koriyama
+Copyright (c) 2015-2025 Akihito Koriyama
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary by Sourcery

CI:
- CI マトリックスを拡張し、旧安定版として PHP 8.3 および 8.4 を追加し、現在の安定版を PHP 8.5 に更新しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Expand the CI matrix to include PHP 8.3 and 8.4 as old stable versions and bump the current stable version to PHP 8.5.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded supported historical versions and advanced the project's current stable version in build/deploy workflows.
  * Updated the copyright year in the project license to 2025.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->